### PR TITLE
update release context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,5 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publishing
+          context: orb-publishing-static-analyzer
           filters: *filters


### PR DESCRIPTION
Updated the release context to our static analysis one. 

This new context can be viewed in CircleCI organization settings.