### PR TITLE
update example rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ You can see an example for repositories based on Python:
 
 ```yaml
 rulesets:
-  - python-security
   - python-code-style
   - python-best-practices
+  - python-inclusive
 ```
 
 ## Workflow


### PR DESCRIPTION
Remove `python-security` from examples and add `python-inclusive`