### PR TITLE
add continue and commented on workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
+      
+      # Publish a development version of the orb as dev:alpha and dev:${COMMIT_SHA}
       - orb-tools/publish:
           orb_name: datadog/datadog-static-analyzer-circleci-orb
           vcs_type: << pipeline.project.type >>
@@ -26,4 +28,12 @@ workflows:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
           context: orb-publishing-static-analyzer
+          filters: *filters
+      
+      # Trigger the next workflow, test-deploy, in our case
+      - orb-tools/continue:
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires:
+            - orb-tools/publish
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ workflows:
       
       # Trigger the next workflow, test-deploy, in our case
       - orb-tools/continue:
+          orb_name: datadog/datadog-static-analyzer-circleci-orb
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
           requires:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,7 +29,7 @@ workflows:
           # Use a context to hold your publishing token.
           context: orb-publishing-static-analyzer
           pub_type: production
-          enable-pr-comment: false
+          enable_pr_comment: false
           # Ensure this we run test and run the pack job
           requires:
             - orb-tools/pack

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,5 +1,4 @@
 version: 2.1
-setup: true
 orbs:
   orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -4,29 +4,34 @@ orbs:
   orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
 
+# always run checks
 filters: &filters
   tags:
     only: /.*/
+
+# only run on release tags
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    # https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 workflows:
   test-deploy:
     jobs:
       - orb-tools/pack:
           filters: *filters
+      
       # Publish a production version of the orb.
       - orb-tools/publish:
           orb_name: datadog/datadog-static-analyzer-circleci-orb
-          vcs-type: << pipeline.project.type >>
+          vcs_type: << pipeline.project.type >>
           # Use a context to hold your publishing token.
           context: orb-publishing-static-analyzer
-          pub-type: production
+          pub_type: production
           enable-pr-comment: false
+          # Ensure this we run test and run the pack job
           requires:
             - orb-tools/pack
-          # Run only for semantic tags
-          # https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters


### PR DESCRIPTION
## What problem are you trying to solve?

We don't trigger the `test-deploy` workflow because the `config` workflow doesn't have a continue job

## What is your solution?

Add a continue job.

## Alternatives considered

None

## What the reviewer should know

Added comments to the `config` and `test-deploy` workflows to help understandability for future developers