### PR TITLE
make git info accessible by datadog-ci

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,3 +2,4 @@ Component,Origin,License,Copyright
 @datadog/datadog-ci,core,Apache-2.0,"Copyright 2019-Present Datadog, Inc."
 openjdk-17-jdk,core,GPL-2.0,"Copyright 2023 Oracle Corporation and/or its affiliates"
 unzip,core,BSD-3-Clause,"Copyright (c) 1990-2009 Info-ZIP. All rights reserved"
+git,https://github.com/git/git,GPL-2.0,© 2005-2023, Linus Torvalds and others.

--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -128,7 +128,7 @@ $CLI_LOCATION --directory "${PROJECT_ROOT}" -t true -o "${OUTPUT_FILE}" -f sarif
 echo "done"
 
 # navigate to project root, so the datadog-ci command can access the git info
-cd ${PROJECT_ROOT}
+cd "$PROJECT_ROOT" || exit 1
 git config --global --add safe.directory ${PROJECT_ROOT}
 
 echo -n "Uploading results to Datadog ..."

--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -129,7 +129,7 @@ echo "done"
 
 # navigate to project root, so the datadog-ci command can access the git info
 cd "$PROJECT_ROOT" || exit 1
-git config --global --add safe.directory ${PROJECT_ROOT}
+git config --global --add safe.directory "${PROJECT_ROOT}"
 
 echo -n "Uploading results to Datadog ..."
 ${DATADOG_CLI_PATH} sarif upload "${OUTPUT_FILE}" --service "${DD_SERVICE}" --env "$DD_ENV"

--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -129,7 +129,7 @@ echo "done"
 
 # navigate to project root, so the datadog-ci command can access the git info
 cd "$PROJECT_ROOT" || exit 1
-git config --global --add safe.directory "${PROJECT_ROOT}"
+git config --global --add safe.directory "${PROJECT_ROOT}" || exit 1
 
 echo -n "Uploading results to Datadog ..."
 ${DATADOG_CLI_PATH} sarif upload "${OUTPUT_FILE}" --service "${DD_SERVICE}" --env "$DD_ENV"

--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -43,6 +43,7 @@ echo -n "Install dependencies ... "
 sudo apt-get update >/dev/null 2>&1
 sudo apt-get install --yes openjdk-17-jdk >/dev/null 2>&1
 sudo apt-get install --yes unzip >/dev/null 2>&1
+sudo apt-get install --yes git >/dev/null 2>&1
 echo "done"
 
 ########################################################
@@ -126,6 +127,9 @@ echo -n "Starting a static analysis ..."
 $CLI_LOCATION --directory "${PROJECT_ROOT}" -t true -o "${OUTPUT_FILE}" -f sarif || exit 1
 echo "done"
 
+# navigate to project root, so the datadog-ci command can access the git info
+cd ${PROJECT_ROOT}
+git config --global --add safe.directory ${PROJECT_ROOT}
 
 echo -n "Uploading results to Datadog ..."
 ${DATADOG_CLI_PATH} sarif upload "${OUTPUT_FILE}" --service "${DD_SERVICE}" --env "$DD_ENV"


### PR DESCRIPTION
## What problem are you trying to solve?

The `datadog-ci` cannot pick up some git information as it's executed outside of it's scope and `git` is not installed.

## What is your solution?

Install `git`, `cd` into the working directory, and mark the directory as safe.

## Alternatives considered

None

## What the reviewer should know

Since `git` was installed, we've added it to the `LICENSE-3rdparty.csv` file.