### PR TITLE
Use only major version to install the CircleCI Orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following is a sample workflow file.
 ```yaml
 version: 2.1
 orbs:
-  datadog-static-analysis: datadog/datadog-static-analyzer-circleci-orb@1.0.0
+  datadog-static-analysis: datadog/datadog-static-analyzer-circleci-orb@1
 jobs:
   run-static-analysis-job:
     docker:


### PR DESCRIPTION
## What problem are you trying to solve?
The snippet of code used to illustrate how to use the CircleCI Orb needs to be updated every time we release a minor or bugfix version of the Orb. This might imply the customer will not use the most updated version of the CircleCI Orb either.

## What is your solution?
Use the short form `@1` to set only the major version, allowing the customer to use always the most latest released version of the Orb.

## What the reviewer should know
This Orb does not require an additional tag pointing to the latest released version as CircleCI supports [semantic versioning](https://circleci.com/docs/orb-concepts/#semantic-versioning)