### PR TITLE
Get result SHA fingerprint with `-g` option

### DIFF
--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -142,8 +142,6 @@ echo -n "Starting a static analysis ..."
 $CLI_LOCATION -g -i "${PROJECT_ROOT}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
 echo "done"
 
-cat "$OUTPUT_FILE"
-
 echo -n "Uploading results to Datadog ..."
 ${DATADOG_CLI_PATH} sarif upload "${OUTPUT_FILE}" --service "${DD_SERVICE}" --env "$DD_ENV" || exit 1
 echo "Done"

--- a/src/scripts/analyze.sh
+++ b/src/scripts/analyze.sh
@@ -134,13 +134,15 @@ echo "done: will output results at ${OUTPUT_FILE}"
 # execute the tool and upload results
 ########################################################
 
-echo -n "Starting a static analysis ..."
-$CLI_LOCATION -i "${PROJECT_ROOT}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
-echo "done"
-
 # navigate to project root, so the datadog-ci command can access the git info
 cd "$PROJECT_ROOT" || exit 1
 git config --global --add safe.directory "${PROJECT_ROOT}" || exit 1
+
+echo -n "Starting a static analysis ..."
+$CLI_LOCATION -g -i "${PROJECT_ROOT}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
+echo "done"
+
+cat "$OUTPUT_FILE"
 
 echo -n "Uploading results to Datadog ..."
 ${DATADOG_CLI_PATH} sarif upload "${OUTPUT_FILE}" --service "${DD_SERVICE}" --env "$DD_ENV" || exit 1


### PR DESCRIPTION
## What problem are you trying to solve?

We want to store the SHA of the last commit that updated a file where we report a violation.

## What is your solution?

This PR adds the `-g` option to our analyzer to get an SHA, if available, outputted in `result.partialFingerprints.SHA`.

## Alternatives considered

None

## What the reviewer should know

The `checkout` step used in CircleCI will checkout the entire repo, so we don't need to specify a depth like we do with `fetch-depth` in the Github Action. In the future, we may wish to suggest using a more shallow checkout step (which might speed up an analysis on larger repositories).

## Verification

These [5 violations](https://app.datadoghq.com/ci/static-analysis?query=service%3Atest-repo&currentTab=event&index=cicodescan&start=1692900785360&end=1692900924866&paused=true) all include their SHA. [This one in particular](https://app.datadoghq.com/ci/static-analysis?query=service%3Atest-repo&currentTab=event&index=cicodescan&staticAnalysisId=AgAAAYoowOKbTQSQegAAAAAAAAAYAAAAAEFZb293TjByQUFBUVMxYVpMdTlsQUFBQQAAACQAAAAAMDE4YTI4YzAtZTI5Yi00NTBlLThkMWEtYjY0NTgzZjM0NTQ0&trace=AgAAAYoowOKbTQSQegAAAAAAAAAYAAAAAEFZb293TjByQUFBUVMxYVpMdTlsQUFBQQAAACQAAAAAMDE4YTI4YzAtZTI5Yi00NTBlLThkMWEtYjY0NTgzZjM0NTQ0&start=1692900785360&end=1692900924866&paused=true) has the SHA: `dd749e1387c52c98976a38e88f46f76203f824de` which corresponds with where the [change was pushed](https://github.com/DataDog/datadog-static-analyzer-test-repo/commit/dd749e1387c52c98976a38e88f46f76203f824de).